### PR TITLE
fix: cleanup game state on player death

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,6 +42,13 @@ def new_meteroid(meteor_images):
 def spawn_meteoroid_wave(meteor_images):
     spawn_wave(new_meteroid, NUMBER_OF_METEOROIDS, meteor_images)
 
+def clear_game_objects():
+    for meteor in meteors:
+        meteor.kill()
+    for bullet in bullets:
+        bullet.kill()
+
+
 def reset_game():
     global score, game_state, life_gained, player, draw_game_over_screen
 
@@ -55,6 +62,8 @@ def reset_game():
     meteors.empty()
     players.empty()
     stars.empty()
+
+    clear_game_objects()
 
     player = Player(all_sprites, bullets, shoot_sound)
     all_sprites.add(player)
@@ -189,8 +198,7 @@ while running:
                 death_explosion = Explosion(player.rect.center, 'player_explosion', explosion_animation)
                 all_sprites.add(death_explosion)
                 player.hide()
-                for meteor in meteors:
-                    meteor.kill()
+                clear_game_objects()
                 player.lives -= 1
                 player.shield = 100
 

--- a/sprites.py
+++ b/sprites.py
@@ -27,36 +27,38 @@ class Player(pg.sprite.Sprite):
 
 
     def update(self):
-        if self.power >= 2 and pg.time.get_ticks() - self.power_time > POWERUP_TIME:
-            self.power -= 1
-            self.power_time = pg.time.get_ticks()
-
-        # unhide if hidden
-        # self.hidden = False
-        if self.hidden:            
-            if (pg.time.get_ticks() - self.hide_timer) > PLAYER_RESPAWN_TIME:                
-                self.hidden = False
-                self.just_respawned = True
-
-        if self.speedx != 0 and self.speedy != 0:
-            self.speedx = self.speedx / math.sqrt(2)
-            self.speedy = self.speedy / math.sqrt(2)   
-        
-        self.rect.x += self.speedx
-        self.rect.y += self.speedy
-
-        if self.rect.right > WIDTH:
-            self.rect.right = WIDTH
-        if self.rect.left < 0:
-            self.rect.left = 0
-
         if not self.hidden:
+            if self.power >= 2 and pg.time.get_ticks() - self.power_time > POWERUP_TIME:
+                self.power -= 1
+                self.power_time = pg.time.get_ticks()        
+
+            if self.speedx != 0 and self.speedy != 0:
+                self.speedx = self.speedx / math.sqrt(2)
+                self.speedy = self.speedy / math.sqrt(2)   
+
+            self.rect.x += self.speedx
+            self.rect.y += self.speedy
+
+            if self.rect.right > WIDTH:
+                self.rect.right = WIDTH
+            if self.rect.left < 0:
+                self.rect.left = 0
+
             if self.rect.bottom > HEIGHT:
                 self.rect.bottom = HEIGHT
             if self.rect.top < 0:
                 self.rect.top = 0
 
+        # unhide if hidden   
+        else:
+            if (pg.time.get_ticks() - self.hide_timer) > PLAYER_RESPAWN_TIME:
+                self.hidden = False
+                self.just_respawned = True
+
     def update_with_keystate(self, keystate):
+        if self.hidden:
+            return
+                    
         if keystate[pg.K_SPACE]:
             self.shoot()
 


### PR DESCRIPTION
**Fixes for game state cleanup on death:**

- Prevent player movement and shooting while hidden.    
- Kill all bullets and meteors on death for a clean game over screen.