### PR TITLE
feat: add settings menu state with sound effect toggle

### DIFF
--- a/sprites.py
+++ b/sprites.py
@@ -55,12 +55,12 @@ class Player(pg.sprite.Sprite):
                 self.hidden = False
                 self.just_respawned = True
 
-    def update_with_keystate(self, keystate):
+    def update_with_keystate(self, keystate, sound_enabled):
         if self.hidden:
             return
                     
-        if keystate[pg.K_SPACE]:
-            self.shoot()
+        if keystate[pg.K_SPACE]:            
+            self.shoot(sound_enabled)
 
         self.speedx = 0
         if keystate[pg.K_LEFT] and not keystate[pg.K_RIGHT]:
@@ -79,7 +79,7 @@ class Player(pg.sprite.Sprite):
             self.speedy = 0
 
 
-    def shoot(self):
+    def shoot(self, sound_enabled):
         if not self.hidden:
             now = pg.time.get_ticks()
             if now - self.last_shot > self.shoot_delay:            
@@ -88,7 +88,8 @@ class Player(pg.sprite.Sprite):
                     bullet = Bullet(self.rect.centerx, self.rect.top)
                     self.all_sprites.add(bullet)
                     self.bullets.add(bullet)
-                    self.shoot_sound.play()
+                    if sound_enabled:
+                        self.shoot_sound.play()
 
     def hide(self):
         # hide the player temporarily


### PR DESCRIPTION
- Introduce new 'settings' game state accessible from the title screen with ESC
- Implement draw_settings_menu() function to display options and current status
- Add global sound_enabled and music_enabled flags for audio preferences
- Integrate sound_enabled checks for all sound effects (shooting, explosions, death)
- Refactor Player.shoot() method to accept sound_enabled parameter

This provides players with basic audio control and completes the core menu structure for the game. The music_enabled flag is prepped for future background music implementation.