### PR TITLE
feat: add pause menu and state-aware settings access

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -17,6 +17,7 @@ RED = (255, 0, 0)
 GREEN = (0, 255, 0)
 BLUE = (0, 0, 255)
 YELLOW = (255, 255, 0)
+PAUSE_OVERLAY = (0, 0, 0, 128)
 
 BG_COLOUR = BLACK
 


### PR DESCRIPTION
- Implement 'paused' game state triggered by ESC during gameplay
- Add semi-transparent overlay and menu text for pause screen
- Refactor settings menu to remember previous state (pause/title)
- Standardize Q key to 'quit to title' from pause, settings, and game over screens
- Fix drawing order to ensure clean UI in settings and pause states