### PR TITLE
fix: Ensure proper state initialization in PlayState

### DIFF
--- a/play_state.py
+++ b/play_state.py
@@ -11,7 +11,7 @@ class PlayState(BaseState):
         self.death_explosion = None     
 
     def startup(self):
-         pass
+        super().startup()
         
     def get_event(self, event):        
         if event.type == pg.KEYDOWN:


### PR DESCRIPTION
Call super().startup() to maintain state machine integrity:

- BaseState.startup() resets critical flags (done, next_state, quit)

- Without this call, state transitions could behave unexpectedly

- Maintains proper inheritance contract for all state classes

This prevents potential bugs in state transition logic by ensuring complete initialization of the state machine framework.