### PR TITLE
feat: Add TitleState foundation with drawing implementation

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from utilities import draw_text, spawn_wave, draw_icon, draw_icon_text, load_or_
 from game import Game
 from play_state import PlayState
 from pause_state import PauseState
+from title_state import TitleState
 
 
 def load_config():
@@ -22,7 +23,7 @@ def load_config():
     return config_dict
 
 
-def draw_start_title():
+def draw_title_menu():
     icon_x = WIDTH * 0.40
     icon_text_padding_x = 0.06
     text_x = icon_x + WIDTH * icon_text_padding_x
@@ -460,7 +461,7 @@ while running:
             all_sprites_group.draw(screen)
 
         if game_state == "title":
-            draw_start_title()
+            draw_title_menu()
 
         if game_state == "settings":
             draw_settings_menu()

--- a/title_state.py
+++ b/title_state.py
@@ -1,5 +1,6 @@
 import pygame as pg
 from base_state import BaseState
+from utilities import draw_icon, draw_icon_text, draw_text
 
 class TitleState(BaseState):
     def __init__(self, game):
@@ -15,4 +16,24 @@ class TitleState(BaseState):
         pass
 
     def draw(self, surface):
-        pass
+        self.draw_title_menu(surface, self.game)
+
+    def draw_title_menu(self, surface):
+        icon_x = self.game.WIDTH * 0.40
+        icon_text_padding_x = 0.06
+        text_x = icon_x + self.game.WIDTH * icon_text_padding_x
+        icon_y = self.game.HEIGHT * 0.7
+        icon_text_padding_y = 0.026
+        text_y = icon_y + self.game.WIDTH * icon_text_padding_y
+
+        draw_text(surface, "High Score: " + str(self.game.high_score), 22, self.game.WIDTH * 0.5, self.game.HEIGHT * 0.02, self.game.font_name)
+        draw_text(surface, "SHMUP!", 64, self.game.WIDTH / 2, self.game.HEIGHT / 4, self.game.font_name)
+
+        draw_icon(surface, self.graphics_manager.icons["spacebar_icon"], icon_x, icon_y + icon_text_padding_y)
+        draw_icon_text(surface, "Start Game", 22, text_x, text_y, self.game.font_name)
+
+        draw_icon(surface, self.graphics_manager.icons["enter_icon"], self.game.WIDTH * 0.92, self.game.HEIGHT * 0.915)
+        draw_icon_text(surface, "Settings", 18, self.game.WIDTH * 0.78, self.game.HEIGHT * 0.940, self.game.font_name) 
+
+        draw_icon(surface, self.graphics_manager.icons["esc_icon"], self.game.WIDTH * 0.07, self.game.HEIGHT * 0.92)
+        draw_icon_text(surface, "Quit Game", 18, self.game.WIDTH * 0.11, self.game.HEIGHT * 0.940, self.game.font_name)

--- a/title_state.py
+++ b/title_state.py
@@ -1,0 +1,18 @@
+import pygame as pg
+from base_state import BaseState
+
+class TitleState(BaseState):
+    def __init__(self, game):
+        super().__init__(game)
+
+    def startup(self):
+        super().startup()
+
+    def get_event(self, event):
+        pass
+
+    def update(self, dt):
+        pass
+
+    def draw(self, surface):
+        pass


### PR DESCRIPTION
### Changes
- Adds `TitleState` class skeleton following BaseState pattern
- Implements `draw_title_menu()` method with title screen drawing logic
- Maintains full backward compatibility with legacy title system

### Technical Details
- Drawing logic adapted to use `self.game` instead of global variables
- Follows same architectural pattern as PauseState implementation
- Zero breaking changes - legacy code remains fully functional

### Purpose
This lays the foundation for migrating the title screen to the state machine system while maintaining current functionality. The next PR will handle the actual state transition integration.

### Testing
- Verified game launches normally to title screen
- Confirmed all existing title screen functionality works
- No visual or behavioral changes introduced