### PR TITLE
fix: implement smooth sub-pixel movement for meteoroids

### DIFF
--- a/sprites.py
+++ b/sprites.py
@@ -136,14 +136,18 @@ class Meteoroid(pg.sprite.Sprite):
         self.screen_height = screen_height
         self.meteor_images = meteor_images
         self.is_medium = is_medium
+        self.pos = pg.math.Vector2(0, 0) # Float position tracking
         
         # Initialize state
         self.initialize_meteoroid(position, velocity)
 
-    def update(self, dt):        
+    def update(self, dt):
         self.rotate(dt)
-        self.rect.x += self.speedx * dt
-        self.rect.y += self.speedy * dt
+        self.pos.x += self.speedx * dt
+        self.pos.y += self.speedy * dt
+        
+        # Update integer rect for drawing/collision
+        self.rect.center = (int(self.pos.x), int(self.pos.y))
 
         if self.is_off_screen():
             self.initialize_meteoroid()  # Full reset
@@ -162,6 +166,9 @@ class Meteoroid(pg.sprite.Sprite):
         else:
             self.rect.centerx = randrange(self.screen_width - self.rect.width)
             self.rect.bottom = randrange(-METEOROID_SPAWN_Y_MAX, -METEOROID_SPAWN_Y_MIN)
+        
+        self.pos.x = self.rect.centerx
+        self.pos.y = self.rect.centery
 
         # Set velocity
         if velocity:
@@ -196,10 +203,11 @@ class Meteoroid(pg.sprite.Sprite):
     def rotate(self, dt):
             self.rot = (self.rot + self.rot_speed * dt) % 360
             new_image = pg.transform.rotate(self.image_orig, self.rot).convert_alpha()
-            old_center = self.rect.center
+            current_pos = self.pos.copy()
             self.image = new_image
             self.rect = self.image.get_rect()
-            self.rect.center = old_center
+            self.pos = current_pos
+            self.rect.center = (int(self.pos.x), int(self.pos.y))
 
     def is_off_screen(self):
         return (self.rect.top > self.screen_height + self.rect.height or 


### PR DESCRIPTION
- Replaced integer-based position updates with float-based movement using pg.math.Vector2 for precise sub-pixel tracking.
- Added self.pos Vector2 to track exact float positions while maintaining integer rect coordinates for rendering and collision.
- Fixed jerky movement and "teleporting" caused by integer rounding during rotation and movement calculations.
- Preserved original spawn logic using rect.bottom for positioning while using rect.centery for accurate float-based movement center.
- Updated rotate() method to maintain float position during image transformation, preventing position snap-to-integer artifacts.

The fix ensures buttery smooth 60FPS movement even with delta time and rotation, matching the quality of the existing starfield system.