### PR TITLE
chore: replace pygame with pygame-ce

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 altgraph==0.17.4
 packaging==25.0
 pefile==2023.2.7
-pygame==2.6.1
+pygame-ce==2.5.5
 pyinstaller==6.15.0
 pyinstaller-hooks-contrib==2025.8
 pywin32-ctypes==0.2.3


### PR DESCRIPTION
- Uninstalled the deprecated pygame package
- Installed the maintained pygame community edition, pygame-ce
- Updated requirements.txt with the new dependency
- Verified the game still runs correctly with the new library

This change ensures we're using the actively maintained version of Pygame which receives security updates and bug fixes.