### PR TITLE
refactor: migrate game over logic to GameOverState class

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from player import Player
 from systems import SoundManager, GraphicsManager, game_logic
 from utilities import draw_text, spawn_wave, draw_icon, draw_icon_text, load_or_create_file, reset_high_score, draw_confirm_popup
 from game import Game
-from states import PlayState, PauseState, TitleState
+from states import PlayState, PauseState, TitleState, GameOverState
 
 def load_config():
     config_dict = {}
@@ -98,32 +98,6 @@ def draw_settings_menu():
     draw_icon(screen, graphics_manager.arrows["up_icon"], arrow_x - 16, arrow_y - 2 * 16)
     draw_icon(screen, graphics_manager.arrows["down_icon"], arrow_x - 16, arrow_y - 16)
     draw_icon_text(screen, "Move", 18, WIDTH * 0.78, HEIGHT * 0.89, font_name)
-
-def draw_game_over_title(new_high_score_achieved):
-    icon_x = WIDTH * 0.42
-    icon_text_padding_x = 0.06
-    text_x = icon_x + WIDTH * icon_text_padding_x
-    icon_y = HEIGHT * 0.7
-    icon_text_padding_y = 0.026
-    text_y = icon_y + WIDTH * icon_text_padding_y
-    y_increment = 40
-
-    draw_text(screen, "High Score: " + str(game.high_score), 22, WIDTH / 2, 15, font_name)
-    draw_text(screen, "GAME OVER", 48, WIDTH / 2, HEIGHT / 4, font_name)
-    draw_text(screen, "Score: " + str(game.score), 30, WIDTH / 2, HEIGHT * 2 / 5 + y_increment, font_name)
-
-    if new_high_score_achieved:
-        draw_text(screen, "NEW HIGH SCORE!", 30, WIDTH / 2, HEIGHT * 2 / 5, font_name, GREEN)
-
-    draw_icon(screen, graphics_manager.icons["spacebar_icon"], icon_x, icon_y + icon_text_padding_y)
-    draw_icon_text(screen, "Try Again", 22, text_x, text_y, font_name)   
-
-    draw_icon(screen, graphics_manager.icons["esc_icon"], WIDTH * 0.07, HEIGHT * 0.92)
-    draw_icon_text(screen, "Quit to Title", 18, WIDTH * 0.11, HEIGHT * 0.940, font_name)
-
-    draw_icon(screen, graphics_manager.icons["q_icon"], WIDTH * 0.93, HEIGHT * 0.92)
-    draw_icon_text(screen, "Quit Game", 18, WIDTH * 0.770, HEIGHT * 0.940, font_name)
-
 
 def new_star():
     s = Starfield(WIDTH, HEIGHT)
@@ -283,8 +257,9 @@ while running:
             return_state = game.current_state.return_state
 
             if game.current_state.next_state == "GAME_OVER":
-                game_state = "game_over"
-                game.current_state = None
+                # game_state = "game_over"
+                game.current_state = GameOverState(game)
+                # game.current_state = None
 
             elif game.current_state.next_state == "PAUSE":
                 # game_state = "paused"
@@ -398,29 +373,14 @@ while running:
                 if now - message_timer > MESSAGE_DISPLAY_TIME:
                     high_score_reset_message = False  # Hide the message       
 
-        elif game_state == "game_over":
-            if space_key_pressed:
-                start_game()
-                game_state = "playing"
-                game.current_state = PlayState(game)
-                # game.current_state.startup()
-            if q_key_pressed:
-                pending_action = "quit_game"
-                show_confirmation = True
-            if esc_key_pressed:
-                game_state = "title"
-                game.current_state = TitleState(game)
-                # game.current_state.startup()
-
     # --- DRAWING SECTION ---
 
-    if game_state in ("settings", "game_over"):
+    if game_state in ("settings"):
         screen.blit(graphics_manager.background_image, (0, 0))
     else:
         screen.fill(BG_COLOUR)
         
-    # --- MORE NEW CODE: Add this block here in the drawing section ---
-    if game.current_state is not None:        
+    if game.current_state is not None:
         # Let the current state draw itself
         game.current_state.draw(screen)
     else:
@@ -429,11 +389,6 @@ while running:
 
         if game_state == "settings":
             draw_settings_menu()
-            if show_confirmation:
-                draw_confirm_popup(screen, game)       
-
-        if game_state == "game_over":
-            draw_game_over_title(game.new_high_score_achieved)
             if show_confirmation:
                 draw_confirm_popup(screen, game)
 

--- a/states/__init__.py
+++ b/states/__init__.py
@@ -1,5 +1,6 @@
 from .pause_state import PauseState
 from .play_state import PlayState
 from .title_state import TitleState
+from .game_over_state import GameOverState
 
-__all__ = ["PauseState", "PlayState", "TitleState"]
+__all__ = ["PauseState", "PlayState", "TitleState", "GameOverState"]

--- a/states/game_over_state.py
+++ b/states/game_over_state.py
@@ -1,0 +1,77 @@
+import pygame as pg
+from states.base_state import BaseState
+from utilities import draw_text, draw_icon_text, draw_icon
+from settings import *
+
+class GameOverState(BaseState):
+    def __init__(self, game):
+        super().__init__(game)
+        self.show_confirmation = False
+        self.pending_action = None
+    
+    def startup(self):
+        super().startup()
+    
+    def get_event(self, event):
+        if event.type == pg.KEYDOWN:
+            if self.show_confirmation:
+                if event.key == pg.K_y:
+                    if self.pending_action == "quit_game":
+                        self.quit = True
+                        self.done = True
+                    self.show_confirmation = False
+                    self.pending_action = None
+                
+                elif event.key == pg.K_n or event.key == pg.K_ESCAPE:
+                    self.show_confirmation = False
+                    self.pending_action = None
+                    
+            else:
+                if event.key == pg.K_SPACE:
+                        # start_game()
+                        self.done = True
+                        self.next_state = "PLAY"
+                        # game.current_state = PlayState(game)
+                        # game.current_state.startup()
+                if event.key == pg.K_q:
+                    self.pending_action = "quit_game"
+                    self.show_confirmation = True
+
+                if event.key == pg.K_ESCAPE:
+                        self.next_state = "TITLE"
+                        # game.current_state = TitleState(game)
+                        # game.current_state.startup()
+    
+    def update(self, dt):
+        # return super().update(dt)
+        self.game.all_sprites_group.update(dt)
+    
+    def draw(self, surface):
+        surface.blit(self.game.graphics_manager.background_image, (0, 0))
+        self.draw_game_over_title(surface)
+    
+    def draw_game_over_title(self, surface):
+        icon_x = self.game.WIDTH * 0.42
+        icon_text_padding_x = 0.06
+        text_x = icon_x + self.game.WIDTH * icon_text_padding_x
+        icon_y = self.game.HEIGHT * 0.7
+        icon_text_padding_y = 0.026
+        text_y = icon_y + self.game.WIDTH * icon_text_padding_y
+        y_increment = 40
+
+        draw_text(surface, "High Score: " + str(self.game.high_score), 22, self.game.WIDTH / 2, 15, self.game.font_name)
+        draw_text(surface, "GAME OVER", 48, self.game.WIDTH / 2, self.game.HEIGHT / 4, self.game.font_name)
+        draw_text(surface, "Score: " + str(self.game.score), 30, self.game.WIDTH / 2, self.game.HEIGHT * 2 / 5 + y_increment, self.game.font_name)
+
+        if self.game.new_high_score_achieved:
+            draw_text(surface, "NEW HIGH SCORE!", 30, self.game.WIDTH / 2, self.game.HEIGHT * 2 / 5, self.game.font_name, GREEN)
+
+        draw_icon(surface, self.game.graphics_manager.icons["spacebar_icon"], icon_x, icon_y + icon_text_padding_y)
+        draw_icon_text(surface, "Try Again", 22, text_x, text_y, self.game.font_name)
+
+        draw_icon(surface, self.game.graphics_manager.icons["esc_icon"], self.game.WIDTH * 0.07, self.game.HEIGHT * 0.92)
+        draw_icon_text(surface, "Quit to Title", 18, self.game.WIDTH * 0.11, self.game.HEIGHT * 0.940, self.game.font_name)
+
+        draw_icon(surface, self.game.graphics_manager.icons["q_icon"], self.game.WIDTH * 0.93, self.game.HEIGHT * 0.92)
+        draw_icon_text(surface, "Quit Game", 18, self.game.WIDTH * 0.770, self.game.HEIGHT * 0.940, self.game.font_name)
+

--- a/states/game_over_state.py
+++ b/states/game_over_state.py
@@ -1,6 +1,6 @@
 import pygame as pg
 from states.base_state import BaseState
-from utilities import draw_text, draw_icon_text, draw_icon
+from utilities import draw_text, draw_icon_text, draw_icon, draw_confirm_popup
 from settings import *
 
 class GameOverState(BaseState):
@@ -28,17 +28,18 @@ class GameOverState(BaseState):
                     
             else:
                 if event.key == pg.K_SPACE:
-                        # start_game()
-                        self.done = True
-                        self.next_state = "PLAY"
+                    # start_game()
+                    self.done = True
+                    self.next_state = "PLAY"
                         # game.current_state = PlayState(game)
                         # game.current_state.startup()
-                if event.key == pg.K_q:
+                elif event.key == pg.K_q:
                     self.pending_action = "quit_game"
                     self.show_confirmation = True
 
-                if event.key == pg.K_ESCAPE:
-                        self.next_state = "TITLE"
+                elif event.key == pg.K_ESCAPE:
+                    self.done = True
+                    self.next_state = "TITLE"
                         # game.current_state = TitleState(game)
                         # game.current_state.startup()
     
@@ -49,6 +50,8 @@ class GameOverState(BaseState):
     def draw(self, surface):
         surface.blit(self.game.graphics_manager.background_image, (0, 0))
         self.draw_game_over_title(surface)
+        if self.show_confirmation:
+            draw_confirm_popup(surface, self.game)
     
     def draw_game_over_title(self, surface):
         icon_x = self.game.WIDTH * 0.42


### PR DESCRIPTION
This PR continues the planned migration from legacy `if/elif` game state logic by moving the comprehensive game over functionality into a proper `GameOverState` class.

### Changes Made
- **New class:** `states/game_over_state.py` containing the migrated game over logic.
- **Removed code:** Deleted the corresponding `elif self.state == "GAMEOVER":` block from `main.py`.
- **Preserved functionality:** The state fully replicates all previous behavior:
  - Displays final score, high score, and new high score indicator.
  - Handles all input options: `SPACE` (play again), `ESC` (title screen), `Q` (quit with confirmation).
  - Utilizes the existing confirmation popup for quit requests.

### Notes
- **The `if/elif` chain in `main.py` still exists,** containing the remaining `SETTINGS` state logic. This will be migrated in a future PR.
- This incremental approach ensures a safe and stable refactor.

### Testing
- Verified all display elements render correctly.
- Confirmed all state transitions work: Play Again -> PlayState, Title -> TitleState.
- Tested the quit confirmation flow remains functional.
- Ensured high score tracking and display operates identically to the previous implementation.