### PR TITLE
fix: correctly restore volume level when unmuting sound

### DIFF
--- a/states/settings_state.py
+++ b/states/settings_state.py
@@ -55,8 +55,7 @@ class SettingsState(BaseState):
                     self.next_state = self.game.previous_state
                        
                 if event.key == pg.K_s:
-                    self.game.sound_manager.sound_enabled = not self.game.sound_manager.sound_enabled
-                    self.game.sound_manager.set_sound_volume(1.0 if self.game.sound_manager.sound_enabled else 0.0)
+                    self.game.sound_manager.toggle_sound()                    
 
                 if event.key == pg.K_m:
                     self.game.sound_manager.music_enabled = self.game.sound_manager.toggle_music()

--- a/systems/sound_manager.py
+++ b/systems/sound_manager.py
@@ -33,7 +33,7 @@ class SoundManager:
             self.update_sound_volume(name)
 
     def update_sound_volume(self, name):
-        final_volume = self.volumes[name] * self.sound_volume
+        final_volume = self.volumes[name] * self.sound_volume * self.sound_enabled
         sound_obj = self.sounds[name]
         if isinstance(sound_obj, list):
             for sound in sound_obj:
@@ -79,3 +79,10 @@ class SoundManager:
         else:
             pg.mixer.music.pause()
         return self.music_enabled
+    
+    def toggle_sound(self):        
+        self.sound_enabled = not self.sound_enabled           
+        self.set_sound_volume(self.sound_volume)
+        
+
+


### PR DESCRIPTION
- Implemented sound toggling logic in new SoundManager.toggle_sound() method
- Fixed volume restoration by using a boolean flag as a multiplier
- Sound now properly returns to its previous volume level after being unmuted