### PR TITLE
fix: prevent premature player shooting on state transitions

### DIFF
--- a/player.py
+++ b/player.py
@@ -26,10 +26,14 @@ class Player(pg.sprite.Sprite):
         self.bullets = game.bullets_group
         self.power = PLAYER_START_POWER
         self.just_respawned = False
+        self.input_cooldown_timer = 0.3
         self.power_time = pg.time.get_ticks()
         self.sound_manager = game.sound_manager
 
     def update(self, dt):
+        if self.input_cooldown_timer > 0:
+            self.input_cooldown_timer -= dt
+            return
         if not self.hidden:
             keystate= pg.key.get_pressed()
             if keystate[pg.K_SPACE]:

--- a/states/game_over_state.py
+++ b/states/game_over_state.py
@@ -28,11 +28,8 @@ class GameOverState(BaseState):
                     
             else:
                 if event.key == pg.K_SPACE:
-                    # start_game()
                     self.done = True
-                    self.next_state = "PLAY"
-                        # game.current_state = PlayState(game)
-                        # game.current_state.startup()
+                    self.next_state = "PLAY"                        
                 elif event.key == pg.K_q:
                     self.pending_action = "quit_game"
                     self.show_confirmation = True
@@ -40,12 +37,6 @@ class GameOverState(BaseState):
                 elif event.key == pg.K_ESCAPE:
                     self.done = True
                     self.next_state = "TITLE"
-                        # game.current_state = TitleState(game)
-                        # game.current_state.startup()
-    
-    def update(self, dt):
-        # return super().update(dt)
-        self.game.all_sprites_group.update(dt)
     
     def draw(self, surface):
         surface.blit(self.game.graphics_manager.background_image, (0, 0))

--- a/states/pause_state.py
+++ b/states/pause_state.py
@@ -40,11 +40,7 @@ class PauseState(BaseState):
                 elif event.key == pg.K_RETURN:
                     self.done = True                    
                     self.next_state = "SETTINGS"
-                    self.game.previous_state = "PAUSE"                    
-
-    def update(self, dt):
-        """Update pause state logic."""
-        # self.game.all_sprites_group.update(dt)
+                    self.game.previous_state = "PAUSE"
 
     def draw(self, surface):
         """Render pause state to surface."""

--- a/states/title_state.py
+++ b/states/title_state.py
@@ -23,10 +23,7 @@ class TitleState(BaseState):
             elif event.key == pg.K_ESCAPE:
                 self.quit = True
                 self.done = True
-
-    def update(self, dt):
-        self.game.all_sprites_group.update(dt)
-
+    
     def draw(self, surface):
         surface.blit(self.game.graphics_manager.background_image, (0, 0))
         self.draw_title_menu(surface)


### PR DESCRIPTION
- Added input cooldown timer to Player class to ignore initial input after being spawned from TitleState or GameOverState
- Discovered and fixed deeper architectural issue: states like TitleState and GameOverState were incorrectly updating the entire game world (all_sprites_group), causing ghost bullets and sounds
- Removed unnecessary all_sprites_group.update() calls from states that only handle UI (TitleState, PauseState, GameOverState)
- Simplified architecture by leveraging BaseState's default pass behavior for states without update needs

The combination of input cooldown and proper state isolation ensures clean transitions without unintended game simulation side effects.